### PR TITLE
Update build-system poetry version to allow editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,5 +124,5 @@ target-version = "py38"
 exclude = []
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,5 +124,5 @@ target-version = "py38"
 exclude = []
 
 [build-system]
-requires = ["poetry>=1.0.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
`pip install -e ../django-url-security` was giving this error:

`ERROR: Project file:///{...}/django-url-security has a 'pyproject.toml' and its build backend is missing the 'build_editable' hook. Since it does not have a 'setup.py' nor a 'setup.cfg', it cannot be installed in editable mode. Consider using a build backend that supports PEP 660.`

The poetry version specified in `pyproject.toml:build-system` needed to be updated.
See https://github.com/python-poetry/poetry/issues/7583#issuecomment-1453161741